### PR TITLE
Make sure only compiles with R16B01 and above

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R15|R16"}.
+{require_otp_vsn, "R16B0[1-3]|17"}.
 
 {cover_enabled, true}.
 

--- a/rel/overlay/rebar.config.src
+++ b/rel/overlay/rebar.config.src
@@ -4,7 +4,7 @@
     "deps"
 ]}.
 
-{require_otp_vsn, "R15|R16"}.
+{require_otp_vsn, "R16B0[1-3]|17"}.
 
 {cover_enabled, true}.
 


### PR DESCRIPTION
bitmessage uses crypto functions not available prior to R16B01. This will prevent rebar from building if you have an unsupported version of Erlang
